### PR TITLE
Improve test for verifying DNS SANs in the issued certificate

### DIFF
--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -532,7 +532,7 @@ class VCertificate:
             self.changed_message.append("CN is %s" % cn)
             return False
         if self.san_dns and \
-            not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
+                not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
             self.changed_message.append("DNS addresses in request: %s and in "
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -535,8 +535,8 @@ class VCertificate:
                                         % (sorted(self.ip_addresses), ips))
             self.changed_message.append("CN is %s" % cn)
             return False
-        if self.san_dns and \
-                not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
+        if self.san_dns and not self._check_dns_sans_correct(
+                dns, self.san_dns, [self.common_name]):
             self.changed_message.append("DNS addresses in request: %s and in "
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -531,7 +531,7 @@ class VCertificate:
                                         % (sorted(self.ip_addresses), ips))
             self.changed_message.append("CN is %s" % cn)
             return False
-        if not _check_dns_sans_correct(self.san_dns, dns, [cn]):
+        if not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
             self.changed_message.append("DNS addresses in request: %s and in "
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -461,6 +461,24 @@ class VCertificate:
         if self.module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
+    def _check_dns_sans_correct(actual, required, optional):
+        if len(optional) == 0 and len(actual) != len(required):
+            return False
+        for i in required:
+            found = False
+            for j in actual:
+                found = found or (i == j)
+            if not found:
+                return False
+            combined = required + optional
+            for i in actual:
+                found = False
+                for j in combined:
+                    found = found or (i == j)
+            if not found:
+                return False
+        return True
+
     def _check_certificate_validity(self, cert, validate):
         cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
         if cn != self.common_name:
@@ -518,24 +536,6 @@ class VCertificate:
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))
             return False
-        return True
-
-    def _check_dns_sans_correct(actual, required, optional):
-        if len(optional) == 0 and len(actual) != len(required):
-            return False
-        for i in required:
-            found = False
-            for j in actual:
-                found = found or (i == j)
-            if not found:
-                return False
-            combined = required + optional
-            for i in actual:
-                found = False
-                for j in combined:
-                    found = found or (i == j)
-            if not found:
-                return False
         return True
 
     def _check_public_key_matched_to_private_key(self, cert):

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -467,14 +467,18 @@ class VCertificate:
         for i in required:
             found = False
             for j in actual:
-                found = found or (i == j)
+                if i == j:
+                    found = True
+                    break
             if not found:
                 return False
-            combined = required + optional
-            for i in actual:
-                found = False
-                for j in combined:
-                    found = found or (i == j)
+        combined = required + optional
+        for i in actual:
+            found = False
+            for j in combined:
+                if i == j:
+                    found = True
+                    break
             if not found:
                 return False
         return True

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -531,7 +531,7 @@ class VCertificate:
                                         % (sorted(self.ip_addresses), ips))
             self.changed_message.append("CN is %s" % cn)
             return False
-        if not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
+        if self.san_dns and not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
             self.changed_message.append("DNS addresses in request: %s and in "
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -531,7 +531,8 @@ class VCertificate:
                                         % (sorted(self.ip_addresses), ips))
             self.changed_message.append("CN is %s" % cn)
             return False
-        if self.san_dns and not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
+        if self.san_dns and \
+            not self._check_dns_sans_correct(self.san_dns, dns, [cn]):
             self.changed_message.append("DNS addresses in request: %s and in "
                                         "certificate: %s are different"
                                         % (sorted(self.san_dns), sorted(dns)))

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -520,23 +520,23 @@ class VCertificate:
             return False
         return True
 
-	def _check_dns_sans_correct(actual, required, optional):
-		if len(optional) == 0 and len(actual) != len(required):
-			return False
-		for i in required:
-			found = False
-			for j in actual:
-				found = found or (i == j)
-			if not found:
-				return False
-		combined = required + optional
-		for i in actual:
-			found = False
-			for j in combined:
-				found = found or (i == j)
-			if not found:
-				return False
-		return True
+    def _check_dns_sans_correct(actual, required, optional):
+        if len(optional) == 0 and len(actual) != len(required):
+            return False
+        for i in required:
+            found = False
+            for j in actual:
+                found = found or (i == j)
+            if not found:
+                return False
+            combined = required + optional
+            for i in actual:
+                found = False
+                for j in combined:
+                    found = found or (i == j)
+            if not found:
+                return False
+        return True
 
     def _check_public_key_matched_to_private_key(self, cert):
         if not self.privatekey_filename:

--- a/library/venafi_certificate.py
+++ b/library/venafi_certificate.py
@@ -461,7 +461,7 @@ class VCertificate:
         if self.module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
-    def _check_dns_sans_correct(actual, required, optional):
+    def _check_dns_sans_correct(self, actual, required, optional):
         if len(optional) == 0 and len(actual) != len(required):
             return False
         for i in required:


### PR DESCRIPTION
Since the behavior of automatically adding common name (CN) as a DNS subject alternative name (SAN) in the issued certificate varies by certificate authority, it is appropriate for the test to pass whether the CN is added or not.  This test was too restrictive and began failing when the Venafi Cloud built-in CA behavior changed from automatically including the CN as a DNS SAN to requiring it to be explicitly specified in the certificate request. 