### PR TITLE
Update of author name for galaxy info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Alexander Rykalin
+  author: Venafi
   description: Streamline machine identity (certificate and key) acquisition using Venafi vcert.
   company: Venafi, Inc.
 


### PR DESCRIPTION
The jenkins job is failing due linter is detecting that the author's name is not valid. Replacing the current value by "Venafi"